### PR TITLE
do not delete this.options.html

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ function UncssFilter(inputTree, options) {
 	}
 
 	this.html = this.options.html;
-	delete this.options.html;
 }
 
 UncssFilter.prototype = Object.create(Filter.prototype);


### PR DESCRIPTION
I have a setup where I am processing two trees and the `html` option is the same for both:

```
var uncssOptions = { html: ['./index.html'] };
vendorCss = uncss(vendorCss, uncssOptions);
appCss = uncss(appCss, uncssOptions);
```

This causes an error:

```
throw new Error('`html` option required');
```

So, to be able to share a single options object I removed the delete statement.
